### PR TITLE
Add copy link option

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import {
   FolderOpen,
   ListIcon,
   PencilIcon,
+  Copy,
   Plus,
   SearchIcon,
   Share,
@@ -965,6 +966,22 @@ function App() {
                           >
                             <FolderOpen className="size-4" />
                             Move to folder
+                          </ContextMenuItem>
+                          <ContextMenuItem
+                            onSelect={async () => {
+                              try {
+                                await navigator.clipboard.writeText(bookmark.url!);
+                                toast("Link copied to clipboard");
+                              } catch (error) {
+                                toast("Failed to copy link", {
+                                  description: "Unable to access clipboard",
+                                });
+                                console.log(error);
+                              }
+                            }}
+                          >
+                            <Copy className="size-4" />
+                            Copy link
                           </ContextMenuItem>
                           <ContextMenuItem
                             onSelect={async () => {


### PR DESCRIPTION
## Summary
- add `Copy` icon import
- add context menu item for copying link URLs

## Testing
- `npm run lint`
- `npm run build` *(fails: cannot find module './lib/bookmark-utils' and other ts errors)*

------
https://chatgpt.com/codex/tasks/task_e_686448110ea08330a61c86690eb8c08d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Copy link" option to the bookmark context menu, allowing users to copy bookmark URLs directly to the clipboard with a single click.
  * Displays a toast notification confirming success or failure when copying a link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->