### PR TITLE
Add copy link context menu option

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { Tabs, TabsList, TabsTrigger } from "./components/ui/tabs";
 
 import {
   Check,
+  Copy,
   FolderOpen,
   ListIcon,
   PencilIcon,
@@ -965,6 +966,22 @@ function App() {
                           >
                             <FolderOpen className="size-4" />
                             Move to folder
+                          </ContextMenuItem>
+                          <ContextMenuItem
+                            onSelect={async () => {
+                              try {
+                                await navigator.clipboard.writeText(
+                                  bookmark.url!
+                                );
+                                toast("Link copied to clipboard");
+                              } catch {
+                                toast("Failed to copy link", {
+                                  description: "Unable to access clipboard",
+                                });
+                              }
+                            }}
+                          >
+                            <Copy className="size-4" /> Copy link
                           </ContextMenuItem>
                           <ContextMenuItem
                             onSelect={async () => {


### PR DESCRIPTION
## Summary
- include `Copy` icon
- implement copy link option in bookmark context menu
- run lint

## Testing
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686448110ea08330a61c86690eb8c08d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Copy link" option to the bookmark context menu, allowing users to copy bookmark URLs directly to the clipboard with success or error notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->